### PR TITLE
Fix drag-and-drop calendar import compatibility

### DIFF
--- a/src/components/calendar/StudyCalendar.tsx
+++ b/src/components/calendar/StudyCalendar.tsx
@@ -5,7 +5,7 @@
 import React, { useMemo, useCallback, useState } from 'react';
 import { Calendar, dateFnsLocalizer, Views } from 'react-big-calendar';
 import type { SlotInfo, View } from 'react-big-calendar';
-import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
+import withDragAndDropModule from 'react-big-calendar/lib/addons/dragAndDrop';
 import { format, parse, startOfWeek, getDay } from 'date-fns';
 import { enUS } from 'date-fns/locale';
 import type { CalendarEvent } from '../../types';
@@ -29,6 +29,13 @@ const localizer = dateFnsLocalizer({
 /**
  * Create drag-and-drop calendar
  */
+const withDragAndDrop =
+  (
+    withDragAndDropModule as typeof withDragAndDropModule & {
+      default?: typeof withDragAndDropModule;
+    }
+  ).default ?? withDragAndDropModule;
+
 const DnDCalendar = withDragAndDrop<CalendarEvent, object>(Calendar);
 
 /**


### PR DESCRIPTION
### Motivation
- The calendar failed to render (blank page) due to a runtime error caused by CJS/ESM default-export interop when importing the react-big-calendar drag-and-drop addon.

### Description
- Normalize the drag-and-drop addon import in `src/components/calendar/StudyCalendar.tsx` by importing the module as `withDragAndDropModule` and resolving `.default` when present to support both CJS and ESM bundles.
- Keep the existing drag-and-drop calendar initialization (`DnDCalendar`) and usage unchanged, only adjust the import/interop logic.

### Testing
- Ran `npm run build` and the production build completed successfully without the previous runtime error.
- Started the dev server and executed a Playwright script to load `http://127.0.0.1:4173/`; the page loaded and a screenshot was captured and saved by the automated script with no `withDragAndDrop is not a function` page errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982ce8c667c8320ae4b6cd2befc70c5)